### PR TITLE
Fix repo start to not treat badges as repositories

### DIFF
--- a/.github/scripts/update_search_badges.sh
+++ b/.github/scripts/update_search_badges.sh
@@ -4,7 +4,7 @@ GITHUB_SEARCH="https://github.com/search/advanced?q="
 GITHUB_SEARCH_TYPE="\&type=Code"
 BADGE_START="[![search](https://img.shields.io/badge/search-"
 BADGE_END="-orange?style=for-the-badge)]"
-REPOS_START='## Home GitOps Kubernetes clusters'
+REPOS_START='Repository'
 REPOS_END="## Helm chart repositories"
 
 # extract list of repos from readme


### PR DESCRIPTION
**Description of the change**

The first two entries of the search badges were empty making the search fail, this was due to search badges being included in the Home GitOps Kubernetes clusters section.

**Benefits**

Now searches should work out-of-the-box

**Possible drawbacks**

None that I can think of

**Applicable issues**

N/A

**Additional information**

N/A
