### PR TITLE
Added geekdojo script for netbooting any number of Raspberry PIs with…

### DIFF
--- a/data.json
+++ b/data.json
@@ -212,6 +212,10 @@
       "repo": "Truxnell/home-cluster",
       "description": "Sidero/Talos cluster defined with GitOps/Flux.  Utilizing SOPS & Renovate.  Raspi4 8GB Master + 3 Intel NUC Workers.",
       "gitops_tool": "flux"
+    },
+    {
+      "repo": "geekdojo-ofc/rpi-talos-netboot",
+      "description": "Re-runnable script for standing up N number of Talos nodes on Raspberry PIs using Netboot (dnsmasq+apache)."
     }
   ],
   "chart_repositories": [


### PR DESCRIPTION
… Talos.

Signed-off-by: Bryce <BryceAshey@users.noreply.github.com>

<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

Added an entry for GeekDojo's Talos netboot script.

**Benefits**

The script takes in the serial numbers of n number of PIs and will configure dnsmasq and apache on a node to support netbooting. It adjusts the number of control planes between 1 and 3 based on the number of Talos nodes configured. Four or more will create an HA cluster.

**Possible drawbacks**

Likely none.

**Applicable issues**

Initial script release. There is still a little more polish to do but it runs repeatably.

**Additional information**

The script cleans up before each run so it can be run as many times as desired.
