### PR TITLE
Update buvis repo

### DIFF
--- a/data.json
+++ b/data.json
@@ -174,7 +174,7 @@
       "gitops_tool": "flux"
     },
     {
-      "repo": "buvis-net/clusters",
+      "repo": "buvis/clusters",
       "description": "Clusters on Proxmox and bare metal managed by Flux2",
       "gitops_tool": "flux"
     },


### PR DESCRIPTION
Hello,

Recently https://github.com/buvis became free, so I took it to be more consistent with how I name things. Therefore the repository I use for gitops changed from buvis-net/clusters to buvis/clusters.

Can you please update your list?

Thank you.

Cheers, Tomas